### PR TITLE
[CYP-758] Add toolVersion attribute in publication model

### DIFF
--- a/models/publication.go
+++ b/models/publication.go
@@ -10,6 +10,7 @@ import (
 
 // Publication Main structure for a publication
 type Publication struct {
+	ToolVersion  string   `json:"toolVersion"`
 	Context      []string `json:"@context,omitempty"`
 	Metadata     Metadata `json:"metadata"`
 	Links        []Link   `json:"links"`
@@ -311,4 +312,8 @@ func (publication *Publication) TransformLinkToFullURL(baseURL string) {
 			publication.Landmarks[i].Href = baseURL + publication.Landmarks[i].Href
 		}
 	}
+}
+
+func (publication *Publication) GetToolVersion() string {
+	return publication.ToolVersion
 }


### PR DESCRIPTION
It adds new attribute (toolVersion) in publication model which will be used to identify the version of binaries used to generate processed files.
